### PR TITLE
accept leading v in version number

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,4 @@
+rules:
+  github-env:
+    ignore:
+      - action.yml:42

--- a/action.yml
+++ b/action.yml
@@ -36,9 +36,10 @@ runs:
     - name: Setup xk6
       shell: bash
       id: setup
+      env:
+        DIR: ${{ inputs.dir }}
+        VERSION: ${{ inputs.xk6-version }}
       run: |
-        VERSION="${{ inputs.xk6-version }}"
-
         if [ -z "$VERSION" ] || [ "$VERSION" == "latest" ]; then
             url=$(curl -s -I "https://github.com/grafana/xk6/releases/latest" | grep -i location)
             VERSION="${url##*v}"
@@ -65,17 +66,17 @@ runs:
         "X64") ARCH="amd64" ;;
         esac
 
-        mkdir -p ${{ inputs.dir }}
+        mkdir -p "$DIR"
 
         if [ "$OS" == "windows" ]; then
           curl -s -L -o /tmp/xk6-$$.zip "https://github.com/grafana/xk6/releases/download/v${VERSION}/xk6_${VERSION}_${OS}_${ARCH}.zip"
-          unzip /tmp/xk6-$$.zip xk6.exe -d ${{ inputs.dir }}
+          unzip /tmp/xk6-$$.zip xk6.exe -d "$DIR"
           rm -f /tmp/xk6-$$.zip
         else
           wget -qO - "https://github.com/grafana/xk6/releases/download/v${VERSION}/xk6_${VERSION}_${OS}_${ARCH}.tar.gz" | \
-            tar x -zf - -C ${{ inputs.dir }} xk6
+            tar x -zf - -C "$DIR" xk6
         fi
 
-        echo ${{ inputs.dir }} >> $GITHUB_PATH
+        echo "$DIR" >> $GITHUB_PATH
         echo XK6_EARLY_ACCESS=true >> $GITHUB_ENV
         echo "xk6-version=$VERSION" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,8 @@ runs:
             url=$(curl -s -I "https://github.com/grafana/xk6/releases/latest" | grep -i location)
             VERSION="${url##*v}"
             VERSION=${VERSION//[[:space:]]/}
+        else
+            VERSION="${VERSION##*v}"
         fi
 
         OS=""


### PR DESCRIPTION
This change introduces a small quality-of-life improvement for the `xk6-version` input, making the action more forgiving and aligning it with common GitHub versioning practices.

### Enhancement

  * **Accept Leading `v` in `xk6-version`:** The action now correctly parses and accepts version numbers that are prefixed with a leading `v` character (e.g., `v0.10.1`). Previously, only versions without the prefix (e.g., `0.10.1`) were supported.

### **Why this matters**

Many users and tools tag releases with a leading `v` (like `v1.0.0`). This change prevents installation failures and friction when users reference these common tag formats in their workflow YAML:

```yaml
- uses: grafana/setup-xk6@v1.0.1
  with:
    # This now works correctly
    xk6-version: 'v1.2.3'
```